### PR TITLE
Upgrade dependencies

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -18,7 +18,7 @@
     "eslint-config-datarockets-base": "latest"
   },
   "peerDependencies": {
-    "babel-eslint": "^10.0.1",
+    "@babel/eslint-parser": "^7.18.2",
     "eslint": "^7.5",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.14.1",
+    "eslint": "^7.5",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.12.4"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -14,7 +14,7 @@
     "react"
   ],
   "dependencies": {
-    "eslint-config-airbnb": "^17.0.0",
+    "eslint-config-airbnb": "^19.0.4",
     "eslint-config-datarockets-base": "latest"
   },
   "peerDependencies": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -14,7 +14,7 @@
   ],
   "peerDependencies": {
     "stylelint": "^13.8",
-    "stylelint-config-standard": "^18.2.0"
+    "stylelint-config-standard": "^20"
   },
   "version": "0.0.4-6"
 }

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -13,7 +13,7 @@
     "linter"
   ],
   "peerDependencies": {
-    "stylelint": "^9.10.1",
+    "stylelint": "^13.8",
     "stylelint-config-standard": "^18.2.0"
   },
   "version": "0.0.4-6"


### PR DESCRIPTION
Changes:
- Upgrade versions of eslint, eslint-config-airbnb, eslint-config-airbnb-base, stylelint, stylelint-config-standard
- Use @babel/eslint-parser instead of deprecated babel-eslint

Note:
Need to be merged after https://github.com/datarockets/style-guide/pull/38