### PR TITLE
Upgrade eslint-config-base dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [8]
+        node: [10, 12, 14, 16]
 
     runs-on: ubuntu-latest
 

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -13,7 +13,7 @@
     "linter"
   ],
   "dependencies": {
-    "eslint-config-airbnb-base": "^13.1.0"
+    "eslint-config-airbnb-base": "^15.0.0"
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -17,7 +17,7 @@
   },
   "peerDependencies": {
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.14.1",
+    "eslint": "^7.5",
     "eslint-plugin-import": "^2.16.0"
   },
   "version": "0.0.4-6"

--- a/packages/eslint-config-base/package.json
+++ b/packages/eslint-config-base/package.json
@@ -16,7 +16,7 @@
     "eslint-config-airbnb-base": "^15.0.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^10.0.1",
+    "@babel/eslint-parser": "^7.18.2",
     "eslint": "^7.5",
     "eslint-plugin-import": "^2.16.0"
   },


### PR DESCRIPTION
Changes in eslint-config-base:

- Upgrade versions of eslint, eslint-config-airbnb-base
- Use @babel/eslint-parser instead of deprecated babel-eslint